### PR TITLE
Fix a spelling error and some lint nits.

### DIFF
--- a/lib/Technique/Evaluator.hs
+++ b/lib/Technique/Evaluator.hs
@@ -7,7 +7,7 @@ Given an instantiated Technique Procedure, evalutate it at runtime.
 -- converted to a typeclass in the tagless final style.
 module Technique.Evaluator where
 
-import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader.Class (MonadReader(..))
 import Control.Monad.Trans.Reader (ReaderT(..))
 import Core.Data
@@ -65,7 +65,7 @@ evaluateStep step = case step of
 
     Asynchronous _ names substep -> do
         promise <- assignNames names substep
-        undefined -- TODO put primise into environment
+        undefined -- TODO put promise into environment
 
     Invocation _ attr func substep -> do
         functionApplication func substep   -- TODO do something with role!

--- a/lib/Technique/Translate.hs
+++ b/lib/Technique/Translate.hs
@@ -366,7 +366,7 @@ Update the environment's idea of where in the source we are, so that if we
 need to generate an error message we can offer one with position
 information.
 -}
-setLocationFrom :: (Render a, Located a) => a -> Translate ()
+setLocationFrom :: (Located a) => a -> Translate ()
 setLocationFrom thing = do
     env <- get
     let source = environmentSource env


### PR DESCRIPTION
I was browsing through the code to get familiar with things and my editor found a few things that it wasn't happy with.

There are a few other things (unused vars, non-canonical monoid definitions, and partial pattern match functions) that flag up, but I don't (yet) have enough context to tackle those.

I look forward to your feedback. :)

All best!