### PR TITLE
Change to internal library to hide internals

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,31 +30,32 @@ dependencies:
 
 ghc-options: -Wall -Wwarn -fwarn-tabs
 
-library:
-  dependencies:
-    - async
-    - hashable
-    - mtl
-    - transformers
-    - uuid-types
-  source-dirs: lib
-  exposed-modules:
-    - Technique.Builtins
-    - Technique.Diagnostics
-    - Technique.Evaluator
-    - Technique.Failure
-    - Technique.Formatter
-    - Technique.Language
-    - Technique.Internal
-    - Technique.Parser
-    - Technique.Quantity
-    - Technique.Translate
-  other-modules: []
+internal-libraries:
+  technique-internal:
+    dependencies:
+      - async
+      - hashable
+      - mtl
+      - transformers
+      - uuid-types
+    source-dirs: lib
+    exposed-modules:
+      - Technique.Builtins
+      - Technique.Diagnostics
+      - Technique.Evaluator
+      - Technique.Failure
+      - Technique.Formatter
+      - Technique.Language
+      - Technique.Internal
+      - Technique.Parser
+      - Technique.Quantity
+      - Technique.Translate
+    other-modules: []
 
 executables:
   technique:
     dependencies:
-      - technique
+      - technique-internal
     ghc-options: -threaded
     source-dirs: src
     main: TechniqueMain.hs
@@ -65,7 +66,7 @@ tests:
   check:
     dependencies:
       - hspec
-      - technique
+      - technique-internal
 # and, because no multi-cradle support:
       - async
       - hashable


### PR DESCRIPTION
At present **technique** is not exposed as a library for other programs to use; while we may well end up in this direction it would be better to hide the implementation internals for now.

Switching to `internal-libraries:` in the _package.yaml_ appears, however, to break `stack ghci`:

```
<command line>: cannot satisfy -package z-technique-z-technique-internal
    (use -v for more information)
```

which is odd but then internal-libraries are a bit of a new idea. So holding off on this for now.