### PR TITLE
Canonicalise the Step Semigroup/Monoid instances to avoid backwards mappend definition

### DIFF
--- a/lib/Technique/Internal.hs
+++ b/lib/Technique/Internal.hs
@@ -129,13 +129,12 @@ instance Located Step where
         Nested o _ -> o
 
 instance Semigroup Step where
-    (<>) = mappend
+    (<>) NoOp s2 = s2
+    (<>) s1 NoOp = s1
+    (<>) (Nested o1 list1) (Nested _ list2) = Nested o1 (append list1 list2)
+    (<>) (Nested o1 list1) s2 = Nested o1 (snoc list1 s2)
+    (<>) s1 (Nested _ list2) = Nested (locationOf s1) (cons s1 list2)
+    (<>) s1 s2 = Nested (locationOf s1) (snoc (singleton s1) s2)
 
 instance Monoid Step where
     mempty = NoOp
-    mappend NoOp s2 = s2
-    mappend s1 NoOp = s1
-    mappend (Nested o1 list1) (Nested _ list2) = Nested o1 (append list1 list2)
-    mappend (Nested o1 list1) s2 = Nested o1 (snoc list1 s2)
-    mappend s1 (Nested _ list2) = Nested (locationOf s1) (cons s1 list2)
-    mappend s1 s2 = Nested (locationOf s1) (snoc (singleton s1) s2)


### PR DESCRIPTION
The definitions of mappend in Monoid instances must be equivalent to (<>) in their nominal Semigroup
instances. Future removal of mappend from Monoid will break non-canonical
instances (i.e. instances which define (<>) as equal to mappend; oft called
'backwards' definition). Moving the specialisation of (<>) from Monoid into
Semigroup, where the assocative property constraint is introduced, permits
reuse and further specialisation elsewhere.

WARNING: I have not verified that Semigroup Associativity law holds for
the current definition of (<>) in Semigroup Step - I've just moved it
in from Monoid Step.