### PR TITLE
Use pest to parse Technique procedure files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +107,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +143,16 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -170,6 +218,51 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pest"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -247,6 +340,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +387,8 @@ name = "technique"
 version = "0.3.0"
 dependencies = [
  "clap",
+ "pest",
+ "pest_derive",
  "serde",
  "tinytemplate",
  "tracing",
@@ -297,6 +403,26 @@ checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -377,6 +503,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +531,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4.5.16", features = [ "wrap_help" ] }
+pest = "2.7.11"
+pest_derive = "2.7.11"
 serde = { version = "1.0.209", features = [ "derive" ] }
 tinytemplate = "1.2.1"
 tracing = "0.1.40"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use tracing::debug;
 use tracing_subscriber;
 
 mod rendering;
+mod parsing;
 
 fn main() {
     const VERSION: &str = concat!("v", env!("CARGO_PKG_VERSION"));
@@ -89,10 +90,11 @@ fn main() {
 
             let filename = submatches
                 .get_one::<String>("filename")
-                .unwrap(); // argument are required by definitin so always present
+                .unwrap(); // argument are required by definition so always present
 
             debug!(filename);
 
+            parsing::load(&Path::new(filename));
             todo!();
         }
         Some(("format", submatches)) => {

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -4,5 +4,8 @@ use std::path::Path;
 pub mod parser;
 
 pub fn load(source: &Path) {
+    // read source to a str
+    let content = std::fs::read_to_string(source).expect("Failed to read the source file");
 
+    parser::parse_via_pest(content.as_str());
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,0 +1,8 @@
+// parser for the Technique language
+use std::path::Path;
+
+pub mod parser;
+
+pub fn load(source: &Path) {
+
+}

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -51,21 +51,21 @@ mod tests {
             .unwrap();
 
         assert_eq!(domain1.as_str(), "Beans");
-        assert_eq!(domain1.as_rule(), Rule::typa);
+        assert_eq!(domain1.as_rule(), Rule::forma);
 
         let domain2 = pairs
             .next()
             .unwrap();
 
         assert_eq!(domain2.as_str(), "Milk");
-        assert_eq!(domain2.as_rule(), Rule::typa);
+        assert_eq!(domain2.as_rule(), Rule::forma);
 
         let range = pairs
             .next()
             .unwrap();
 
         assert_eq!(range.as_str(), "Coffee");
-        assert_eq!(range.as_rule(), Rule::typa);
+        assert_eq!(range.as_rule(), Rule::forma);
     }
 
     #[test]
@@ -78,9 +78,9 @@ mod tests {
                 declaration(0, 37, [
                     identifier(0, 13),
                     signature(16, 37, [
-                        typa(16, 21),
-                        typa(23, 27),
-                        typa(31, 37)
+                        forma(16, 21),
+                        forma(23, 27),
+                        forma(31, 37)
                     ])
                 ])
             ]

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -15,14 +15,17 @@ mod tests {
 
     #[test]
     fn check_procedure_declaration() {
-        let input = "making_coffee : Beans -> Coffee";
+        let input = "making_coffee : Beans, Milk -> Coffee";
 
         let declaration = TechniqueParser::parse(Rule::declaration, &input)
             .expect("Unsuccessful Parse")
             .next()
             .unwrap();
 
-        assert_eq!(declaration.as_str(), "making_coffee : Beans -> Coffee");
+        assert_eq!(
+            declaration.as_str(),
+            "making_coffee : Beans, Milk -> Coffee"
+        );
         assert_eq!(declaration.as_rule(), Rule::declaration);
 
         let mut pairs = declaration.into_inner();
@@ -38,17 +41,28 @@ mod tests {
             .next()
             .unwrap();
 
-        assert_eq!(signature.as_str(), "Beans -> Coffee");
+        assert_eq!(signature.as_str(), "Beans, Milk -> Coffee");
         assert_eq!(signature.as_rule(), Rule::signature);
 
         let mut pairs = signature.into_inner();
 
-        let domain = pairs.next().unwrap();
+        let domain1 = pairs
+            .next()
+            .unwrap();
 
-        assert_eq!(domain.as_str(), "Beans");
-        assert_eq!(domain.as_rule(), Rule::typa);
+        assert_eq!(domain1.as_str(), "Beans");
+        assert_eq!(domain1.as_rule(), Rule::typa);
 
-        let range = pairs.next().unwrap();
+        let domain2 = pairs
+            .next()
+            .unwrap();
+
+        assert_eq!(domain2.as_str(), "Milk");
+        assert_eq!(domain2.as_rule(), Rule::typa);
+
+        let range = pairs
+            .next()
+            .unwrap();
 
         assert_eq!(range.as_str(), "Coffee");
         assert_eq!(range.as_rule(), Rule::typa);

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -89,4 +89,44 @@ mod tests {
             ]
         };
     }
+
+    #[test]
+    fn check_header_spdx() {
+        parses_to! {
+            parser: TechniqueParser,
+            input: "! MIT; (c) ACME, Inc.",
+            rule: Rule::spdx_line,
+            tokens: [
+                spdx_line(0, 21, [
+                    license(2, 5),
+                    copyright(7, 21, [
+                        owner(11, 21)
+                    ])
+                ])
+            ]
+        };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "! MIT; (c) 2024 ACME, Inc.",
+            rule: Rule::spdx_line,
+            tokens: [
+                spdx_line(0, 26, [
+                    license(2, 5),
+                    copyright(7, 26, [
+                        year(11,15),
+                        owner(16, 26)
+                    ])
+                ])
+            ]
+        };
+
+        parses_to! {
+            parser: TechniqueParser,
+            input: "2024",
+            rule: Rule::year,
+            tokens: [
+                year(0,4),
+            ]
+        };
+    }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -7,7 +7,10 @@ use pest_derive::Parser;
 #[grammar = "../technique.pest"]
 struct TechniqueParser;
 
-pub fn load() {}
+pub fn parse_via_pest(content: &str) {
+    let technique = TechniqueParser::parse(Rule::technique, &content);
+    println!("{:?}", technique);
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,0 +1,4 @@
+// parsing machinery
+
+pub fn load() {
+}

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -121,6 +121,41 @@ mod tests {
                 ])
             ]
         };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "! PD",
+            rule: Rule::spdx_line,
+            tokens: [
+                spdx_line(0, 4, [
+                    license(2, 4)
+                ])
+            ]
+        };
+
+        parses_to! {
+            parser: TechniqueParser,
+            input: "MIT",
+            rule: Rule::license,
+            tokens: [
+                license(0,3),
+            ]
+        };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "Public Domain",
+            rule: Rule::license,
+            tokens: [
+                license(0,13),
+            ]
+        };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "CC BY-SA 3.0 IGO",
+            rule: Rule::license,
+            tokens: [
+                license(0,16),
+            ]
+        };
 
         parses_to! {
             parser: TechniqueParser,

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -115,7 +115,7 @@ mod tests {
                 spdx_line(0, 26, [
                     license(2, 5),
                     copyright(7, 26, [
-                        year(11,15),
+                        year(11, 15),
                         owner(16, 26)
                     ])
                 ])
@@ -137,7 +137,7 @@ mod tests {
             input: "MIT",
             rule: Rule::license,
             tokens: [
-                license(0,3),
+                license(0, 3),
             ]
         };
         parses_to! {
@@ -145,7 +145,7 @@ mod tests {
             input: "Public Domain",
             rule: Rule::license,
             tokens: [
-                license(0,13),
+                license(0, 13),
             ]
         };
         parses_to! {
@@ -153,7 +153,7 @@ mod tests {
             input: "CC BY-SA 3.0 IGO",
             rule: Rule::license,
             tokens: [
-                license(0,16),
+                license(0, 16),
             ]
         };
 
@@ -162,7 +162,7 @@ mod tests {
             input: "2024",
             rule: Rule::year,
             tokens: [
-                year(0,4),
+                year(0, 4),
             ]
         };
         parses_to! {
@@ -170,7 +170,7 @@ mod tests {
             input: "2024-",
             rule: Rule::year,
             tokens: [
-                year(0,5),
+                year(0, 5),
             ]
         };
         parses_to! {
@@ -178,7 +178,7 @@ mod tests {
             input: "2002-2024",
             rule: Rule::year,
             tokens: [
-                year(0,9),
+                year(0, 9),
             ]
         };
         fails_with! {
@@ -211,7 +211,6 @@ mod tests {
                 ])
             ]
         };
-
         parses_to! {
             parser: TechniqueParser,
             input: "& nasa-flight-plan-v4.0",
@@ -222,7 +221,6 @@ mod tests {
                 ])
             ]
         };
-
         fails_with! {
             parser: TechniqueParser,
             input: "&",
@@ -230,6 +228,78 @@ mod tests {
             positives: [Rule::template],
             negatives: [],
             pos: 1
+        };
+    }
+
+    #[test]
+    fn check_identifier_rules() {
+        parses_to! {
+            parser: TechniqueParser,
+            input: "p",
+            rule: Rule::identifier,
+            tokens: [
+                identifier(0, 1)
+            ]
+        };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "pizza",
+            rule: Rule::identifier,
+            tokens: [
+                identifier(0, 5)
+            ]
+        };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "cook_pizza",
+            rule: Rule::identifier,
+            tokens: [
+                identifier(0, 10)
+            ]
+        };
+        fails_with! {
+            parser: TechniqueParser,
+            input: "0trust",
+            rule: Rule::identifier,
+            positives: [Rule::identifier],
+            negatives: [],
+            pos: 0
+        };
+    }
+
+    #[test]
+    fn check_declaration_syntax() {
+        parses_to! {
+            parser: TechniqueParser,
+            input: "p :",
+            rule: Rule::declaration,
+            tokens: [
+                declaration(0, 3, [
+                    identifier(0, 1)
+                ])
+            ]
+        };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "p : A -> B",
+            rule: Rule::declaration,
+            tokens: [
+                declaration(0, 10, [
+                    identifier(0, 1),
+                    signature(4, 10, [
+                        forma(4, 5),
+                        forma(9, 10)
+                    ])
+                ])
+            ]
+        };
+        fails_with! {
+            parser: TechniqueParser,
+            input: "cook-pizza :",
+            rule: Rule::declaration,
+            positives: [Rule::declaration],
+            negatives: [],
+            pos: 0
         };
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -265,6 +265,14 @@ mod tests {
             negatives: [],
             pos: 0
         };
+        fails_with! {
+            parser: TechniqueParser,
+            input: "cook-pizza",
+            rule: Rule::identifier,
+            positives: [Rule::identifier],
+            negatives: [],
+            pos: 0
+        };
     }
 
     #[test]

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,6 +1,6 @@
 // parsing machinery
 
-use pest::{consumes_to, parses_to, Parser};
+use pest::Parser;
 use pest_derive::Parser;
 
 #[derive(Parser)]
@@ -14,6 +14,8 @@ pub fn parse_via_pest(content: &str) {
 
 #[cfg(test)]
 mod tests {
+    use pest::{consumes_to, fails_with, parses_to};
+
     use super::*; // Import all parent module items
 
     #[test]
@@ -127,6 +129,40 @@ mod tests {
             tokens: [
                 year(0,4),
             ]
+        };
+    }
+
+    #[test]
+    fn check_header_template() {
+        parses_to! {
+            parser: TechniqueParser,
+            input: "& checklist",
+            rule: Rule::template_line,
+            tokens: [
+                template_line(0, 11, [
+                    template(2, 11)
+                ])
+            ]
+        };
+
+        parses_to! {
+            parser: TechniqueParser,
+            input: "& nasa-flight-plan-v4.0",
+            rule: Rule::template_line,
+            tokens: [
+                template_line(0, 23, [
+                    template(2, 23)
+                ])
+            ]
+        };
+
+        fails_with! {
+            parser: TechniqueParser,
+            input: "&",
+            rule: Rule::template_line,
+            positives: [Rule::template],
+            negatives: [],
+            pos: 1
         };
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,4 +1,36 @@
 // parsing machinery
 
-pub fn load() {
+use pest::Parser;
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar = "../technique.pest"]
+struct TechniqueParser;
+
+pub fn load() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*; // Import all parent module items
+
+    #[test]
+    fn check_procedure_declaration() {
+        let input = "making_coffee : Beans -> Coffee";
+
+        let declaration = TechniqueParser::parse(Rule::declaration, &input)
+            .expect("Unsuccessful Parse")
+            .next()
+            .unwrap();
+
+        assert_eq!(declaration.as_str(), "making_coffee : Beans -> Coffee");
+        assert_eq!(declaration.as_rule(), Rule::declaration);
+
+        let identifier = declaration
+            .into_inner()
+            .next()
+            .unwrap();
+
+        assert_eq!(identifier.as_str(), "making_coffee");
+        assert_eq!(identifier.as_rule(), Rule::identifier);
+    }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -130,6 +130,38 @@ mod tests {
                 year(0,4),
             ]
         };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "2024-",
+            rule: Rule::year,
+            tokens: [
+                year(0,5),
+            ]
+        };
+        parses_to! {
+            parser: TechniqueParser,
+            input: "2002-2024",
+            rule: Rule::year,
+            tokens: [
+                year(0,9),
+            ]
+        };
+        fails_with! {
+            parser: TechniqueParser,
+            input: "02",
+            rule: Rule::year,
+            positives: [Rule::year],
+            negatives: [],
+            pos: 0
+        };
+        fails_with! {
+            parser: TechniqueParser,
+            input: "02-24",
+            rule: Rule::year,
+            positives: [Rule::year],
+            negatives: [],
+            pos: 0
+        };
     }
 
     #[test]

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -25,12 +25,32 @@ mod tests {
         assert_eq!(declaration.as_str(), "making_coffee : Beans -> Coffee");
         assert_eq!(declaration.as_rule(), Rule::declaration);
 
-        let identifier = declaration
-            .into_inner()
+        let mut pairs = declaration.into_inner();
+
+        let identifier = pairs
             .next()
             .unwrap();
 
         assert_eq!(identifier.as_str(), "making_coffee");
         assert_eq!(identifier.as_rule(), Rule::identifier);
+
+        let signature = pairs
+            .next()
+            .unwrap();
+
+        assert_eq!(signature.as_str(), "Beans -> Coffee");
+        assert_eq!(signature.as_rule(), Rule::signature);
+
+        let mut pairs = signature.into_inner();
+
+        let domain = pairs.next().unwrap();
+
+        assert_eq!(domain.as_str(), "Beans");
+        assert_eq!(domain.as_rule(), Rule::typa);
+
+        let range = pairs.next().unwrap();
+
+        assert_eq!(range.as_str(), "Coffee");
+        assert_eq!(range.as_rule(), Rule::typa);
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,6 +1,6 @@
 // parsing machinery
 
-use pest::Parser;
+use pest::{consumes_to, parses_to, Parser};
 use pest_derive::Parser;
 
 #[derive(Parser)]
@@ -14,7 +14,7 @@ mod tests {
     use super::*; // Import all parent module items
 
     #[test]
-    fn check_procedure_declaration() {
+    fn check_procedure_declaration_explicit() {
         let input = "making_coffee : Beans, Milk -> Coffee";
 
         let declaration = TechniqueParser::parse(Rule::declaration, &input)
@@ -66,5 +66,24 @@ mod tests {
 
         assert_eq!(range.as_str(), "Coffee");
         assert_eq!(range.as_rule(), Rule::typa);
+    }
+
+    #[test]
+    fn check_procedure_declaration_macro() {
+        parses_to! {
+            parser: TechniqueParser,
+            input: "making_coffee : Beans, Milk -> Coffee",
+            rule: Rule::declaration,
+            tokens: [
+                declaration(0, 37, [
+                    identifier(0, 13),
+                    signature(16, 37, [
+                        typa(16, 21),
+                        typa(23, 27),
+                        typa(31, 37)
+                    ])
+                ])
+            ]
+        };
     }
 }

--- a/technique.pest
+++ b/technique.pest
@@ -3,14 +3,14 @@
 WHITESPACE = _{ " " | "\t" }
 
 technique = {
-      SOI
-    ~ magic_line
-    ~ NEWLINE
-    ~ spdx_line?
-    ~ NEWLINE+
-    ~ declaration
-    ~ NEWLINE+
-    ~ EOI
+    SOI ~
+    magic_line ~
+    NEWLINE ~
+    spdx_line? ~
+    NEWLINE+ ~
+    declaration ~
+    NEWLINE+ ~
+    EOI
 }
 
 // File Format Header
@@ -19,15 +19,15 @@ magic_line = { "%" ~ "technique" ~ "v1" }
 
 // License and Copyright Header
 
-spdx_line = { "!" ~ license ~ ";" ~ copyright }
+spdx_line = { "!" ~ license ~ (";" ~ copyright)? }
 
-license = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | " " )* }
+license = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | " " | "." )* }
 
 copyright = { ("©" | "(c)" | "(C)") ~ year? ~ owner }
 
-year = @{ ASCII_DIGIT{4} }
+year = @{ ASCII_DIGIT{4} ~ "-" ~ (ASCII_DIGIT{4})? | ASCII_DIGIT{4} }
 
-owner = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | " " | ",")* }
+owner = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | " " | "," | "." )* }
 
 // Procedure Declaration
 

--- a/technique.pest
+++ b/technique.pest
@@ -6,7 +6,7 @@ declaration = { identifier ~ ":"  ~ signature? }
 
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHA | ASCII_DIGIT | "_")* }
 
-signature = { typa ~ "->" ~ typa }
+signature = { typa ~ ("," ~ typa)* ~ "->" ~ typa }
 
 typa = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHA | ASCII_DIGIT)* }
 

--- a/technique.pest
+++ b/technique.pest
@@ -39,7 +39,7 @@ template = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "
 
 // Procedure Declaration
 
-declaration = { identifier ~ ":"  ~ signature? }
+declaration = { identifier ~ ":" ~ signature? }
 
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHA | ASCII_DIGIT | "_")* }
 

--- a/technique.pest
+++ b/technique.pest
@@ -6,9 +6,9 @@ declaration = { identifier ~ ":"  ~ signature? }
 
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHA | ASCII_DIGIT | "_")* }
 
-signature = { typa ~ ("," ~ typa)* ~ "->" ~ typa }
+signature = { forma ~ ("," ~ forma )* ~ "->" ~ forma }
 
-typa = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHA | ASCII_DIGIT)* }
+forma = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHA | ASCII_DIGIT)* }
 
 
 

--- a/technique.pest
+++ b/technique.pest
@@ -2,15 +2,24 @@
 
 WHITESPACE = _{ " " | "\t" }
 
-technique = { SOI ~ magic_line ~ spdx_line? ~ NEWLINE* ~ declaration ~ EOI }
+technique = {
+      SOI
+    ~ magic_line
+    ~ NEWLINE
+    ~ spdx_line?
+    ~ NEWLINE+
+    ~ declaration
+    ~ NEWLINE+
+    ~ EOI
+}
 
 // File Format Header
 
-magic_line = { "%" ~ "technique" ~ "v1" ~ NEWLINE }
+magic_line = { "%" ~ "technique" ~ "v1" }
 
 // License and Copyright Header
 
-spdx_line = { "!" ~ license ~ ";" ~ copyright ~ NEWLINE }
+spdx_line = { "!" ~ license ~ ";" ~ copyright }
 
 license = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | " " )* }
 
@@ -22,7 +31,7 @@ owner = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" 
 
 // Procedure Declaration
 
-declaration = { identifier ~ ":"  ~ signature? ~ NEWLINE }
+declaration = { identifier ~ ":"  ~ signature? }
 
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHA | ASCII_DIGIT | "_")* }
 

--- a/technique.pest
+++ b/technique.pest
@@ -1,0 +1,15 @@
+// Parsing Expression Grammar for v1 of the Technique Procedure Language
+
+WHITESPACE = _{ " " | "\t" }
+
+declaration = { identifier ~ ":"  ~ signature? }
+
+identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHA | ASCII_DIGIT | "_")* }
+
+signature = { type ~ "->" ~ type }
+
+type = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHA | ASCII_DIGIT)* }
+
+
+
+

--- a/technique.pest
+++ b/technique.pest
@@ -6,9 +6,9 @@ declaration = { identifier ~ ":"  ~ signature? }
 
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHA | ASCII_DIGIT | "_")* }
 
-signature = { type ~ "->" ~ type }
+signature = { typa ~ "->" ~ typa }
 
-type = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHA | ASCII_DIGIT)* }
+typa = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHA | ASCII_DIGIT)* }
 
 
 

--- a/technique.pest
+++ b/technique.pest
@@ -7,6 +7,8 @@ technique = {
     magic_line ~
     NEWLINE ~
     spdx_line? ~
+    NEWLINE ~
+    template_line? ~
     NEWLINE+ ~
     declaration ~
     NEWLINE+ ~
@@ -28,6 +30,12 @@ copyright = { ("©" | "(c)" | "(C)") ~ year? ~ owner }
 year = @{ ASCII_DIGIT{4} ~ "-" ~ (ASCII_DIGIT{4})? | ASCII_DIGIT{4} }
 
 owner = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | " " | "," | "." )* }
+
+// Template Header
+
+template_line = { "&" ~ template }
+
+template = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | "." | "," )* }
 
 // Procedure Declaration
 

--- a/technique.pest
+++ b/technique.pest
@@ -2,7 +2,27 @@
 
 WHITESPACE = _{ " " | "\t" }
 
-declaration = { identifier ~ ":"  ~ signature? }
+technique = { SOI ~ magic_line ~ spdx_line? ~ NEWLINE* ~ declaration ~ EOI }
+
+// File Format Header
+
+magic_line = { "%" ~ "technique" ~ "v1" ~ NEWLINE }
+
+// License and Copyright Header
+
+spdx_line = { "!" ~ license ~ ";" ~ copyright ~ NEWLINE }
+
+license = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | " " )* }
+
+copyright = { ("©" | "(c)" | "(C)") ~ year? ~ owner }
+
+year = @{ ASCII_DIGIT{4} }
+
+owner = @{ (ASCII_ALPHA | ASCII_DIGIT) ~ (ASCII_ALPHA | ASCII_DIGIT | "-" | "_" | " " | ",")* }
+
+// Procedure Declaration
+
+declaration = { identifier ~ ":"  ~ signature? ~ NEWLINE }
 
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHA | ASCII_DIGIT | "_")* }
 


### PR DESCRIPTION
Initial work to construct a front-end parser using the **pest** Parsing Expression Grammar library. Includes a top-level grammar file and test cases for individual rules.