### PR TITLE
Improve performance by caching Regex objects

### DIFF
--- a/src/language/types.rs
+++ b/src/language/types.rs
@@ -82,7 +82,7 @@ pub enum Descriptive<'i> {
     Text(&'i str),
     CodeBlock(Expression<'i>),
     Application(Invocation<'i>),
-    Binding(Invocation<'i>, Identifier<'i>),
+    Binding(Box<Descriptive<'i>>, Identifier<'i>),
 }
 
 // types for Steps within procedures

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,10 +1,16 @@
 #![allow(dead_code)]
 
-use std::sync::OnceLock;
-
 use regex::Regex;
 use technique::error::*;
 use technique::language::*;
+
+macro_rules! regex {
+    ($pattern:expr) => {{
+        use std::sync::OnceLock;
+        static REGEX: OnceLock<regex::Regex> = OnceLock::new();
+        REGEX.get_or_init(|| regex::Regex::new($pattern).unwrap_or_else(|e| panic!("{}", e)))
+    }};
+}
 
 pub fn parse_via_taking(content: &str) -> Result<Technique, TechniqueError> {
     let mut input = Parser::new();
@@ -98,36 +104,6 @@ impl<'i> ParsingError<'i> {
         }
     }
 }
-
-static MAGIC_LINE: OnceLock<regex::Regex> = OnceLock::new();
-static SPDX_LINE: OnceLock<regex::Regex> = OnceLock::new();
-static TEMPLATE_LINE: OnceLock<regex::Regex> = OnceLock::new();
-static SIGNATURE: OnceLock<regex::Regex> = OnceLock::new();
-static PROCEDURE_DECLARATION: OnceLock<regex::Regex> = OnceLock::new();
-static STEP_ORDINAL: OnceLock<regex::Regex> = OnceLock::new();
-static SUBSTEP_ORDINAL: OnceLock<regex::Regex> = OnceLock::new();
-static SUBSTEP_PARALLEL: OnceLock<regex::Regex> = OnceLock::new();
-
-static IS_MAGIC_LINE: OnceLock<regex::Regex> = OnceLock::new();
-static IS_SPDX_LINE: OnceLock<regex::Regex> = OnceLock::new();
-static IS_TEMPLATE_LINE: OnceLock<regex::Regex> = OnceLock::new();
-static IS_IDENTIFIER: OnceLock<regex::Regex> = OnceLock::new();
-static IS_SIGNATURE: OnceLock<regex::Regex> = OnceLock::new();
-static IS_GENUS_LIST: OnceLock<regex::Regex> = OnceLock::new();
-static IS_GENUS_TUPLE: OnceLock<regex::Regex> = OnceLock::new();
-static IS_GENUS_SINGLE: OnceLock<regex::Regex> = OnceLock::new();
-static IS_CODE_BLOCK: OnceLock<regex::Regex> = OnceLock::new();
-static IS_FOREACH_KEYWORD: OnceLock<regex::Regex> = OnceLock::new();
-static IS_REPEAT_KEYWORD: OnceLock<regex::Regex> = OnceLock::new();
-static IS_INVOCATION: OnceLock<regex::Regex> = OnceLock::new();
-static IS_FUNCTION: OnceLock<regex::Regex> = OnceLock::new();
-static IS_BINDING: OnceLock<regex::Regex> = OnceLock::new();
-static IS_STEP: OnceLock<regex::Regex> = OnceLock::new();
-static IS_SUBSTEP_DEPENDENT: OnceLock<regex::Regex> = OnceLock::new();
-static IS_SUBSTEP_PARALLEL: OnceLock<regex::Regex> = OnceLock::new();
-static IS_SUBSUBSTEP_DEPENDENT: OnceLock<regex::Regex> = OnceLock::new();
-static IS_ROLE_ASSIGNMENT: OnceLock<regex::Regex> = OnceLock::new();
-static IS_ENUM_RESPONSE: OnceLock<regex::Regex> = OnceLock::new();
 
 #[derive(Debug)]
 struct Parser<'i> {
@@ -458,7 +434,7 @@ impl<'i> Parser<'i> {
     // different natural number here.
     fn read_magic_line(&mut self) -> Result<u8, ParsingError<'i>> {
         self.take_line(|inner| {
-            let re = MAGIC_LINE.get_or_init(|| Regex::new(r"%\s*technique\s+v1").unwrap());
+            let re = regex!(r"%\s*technique\s+v1");
 
             if re.is_match(inner.source) {
                 Ok(1)
@@ -472,9 +448,7 @@ impl<'i> Parser<'i> {
     // to have a license, whereas the copyright part is optional.
     fn read_spdx_line(&mut self) -> Result<(Option<&'i str>, Option<&'i str>), ParsingError<'i>> {
         self.take_line(|inner| {
-            let re = SPDX_LINE.get_or_init(|| {
-                Regex::new(r"^!\s*([^;]+)(?:;\s*(?:\(c\)|\(C\)|©)\s*(.+))?$").unwrap()
-            });
+            let re = regex!(r"^!\s*([^;]+)(?:;\s*(?:\(c\)|\(C\)|©)\s*(.+))?$");
 
             let cap = re
                 .captures(inner.source)
@@ -510,7 +484,7 @@ impl<'i> Parser<'i> {
 
     fn read_template_line(&mut self) -> Result<Option<&'i str>, ParsingError<'i>> {
         self.take_line(|inner| {
-            let re = TEMPLATE_LINE.get_or_init(|| Regex::new(r"^&\s*(.+)$").unwrap());
+            let re = regex!(r"^&\s*(.+)$");
 
             let cap = re
                 .captures(inner.source)
@@ -560,7 +534,7 @@ impl<'i> Parser<'i> {
     fn read_signature(&mut self) -> Result<Signature<'i>, ParsingError<'i>> {
         let content = self.entire();
 
-        let re = SIGNATURE.get_or_init(|| Regex::new(r"\s*(.+?)\s*->\s*(.+?)\s*$").unwrap());
+        let re = regex!(r"\s*(.+?)\s*->\s*(.+?)\s*$");
 
         let cap = match re.captures(content) {
             Some(c) => c,
@@ -597,8 +571,7 @@ impl<'i> Parser<'i> {
         // These capture groups use .+? to make "match more than one, but
         // lazily" so that the subsequent grabs of whitespace and the all
         // important ':' character are not absorbed.
-        let re = PROCEDURE_DECLARATION
-            .get_or_init(|| Regex::new(r"^\s*(.+?)\s*:\s*(.+?)?\s*$").unwrap());
+        let re = regex!(r"^\s*(.+?)\s*:\s*(.+?)?\s*$");
 
         let cap = re
             .captures(self.source)
@@ -896,7 +869,7 @@ impl<'i> Parser<'i> {
 
             // Parse ordinal
 
-            let re = STEP_ORDINAL.get_or_init(|| Regex::new(r"^\s*(\d+)\.\s+").unwrap());
+            let re = regex!(r"^\s*(\d+)\.\s+");
             let cap = re
                 .captures(content)
                 .ok_or(ParsingError::InvalidStep(outer.offset))?;
@@ -946,8 +919,7 @@ impl<'i> Parser<'i> {
             |line| is_substep_dependent(line) || is_role_assignment(line),
             |outer| {
                 let content = outer.entire();
-                let re =
-                    SUBSTEP_ORDINAL.get_or_init(|| Regex::new(r"^\s*([a-hj-uw-z])\.\s+").unwrap());
+                let re = regex!(r"^\s*([a-hj-uw-z])\.\s+");
                 let cap = re
                     .captures(content)
                     .ok_or(ParsingError::InvalidStep(outer.offset))?;
@@ -1002,7 +974,7 @@ impl<'i> Parser<'i> {
             },
             |outer| {
                 let content = outer.entire();
-                let re = SUBSTEP_PARALLEL.get_or_init(|| Regex::new(r"^\s*-\s+").unwrap());
+                let re = regex!(r"^\s*-\s+");
                 let zero = re
                     .find(content)
                     .ok_or(ParsingError::InvalidStep(outer.offset))?;
@@ -1299,25 +1271,25 @@ impl<'i> Parser<'i> {
 }
 
 fn is_magic_line(content: &str) -> bool {
-    let re = IS_MAGIC_LINE.get_or_init(|| Regex::new(r"%\s*technique").unwrap());
+    let re = regex!(r"%\s*technique");
 
     re.is_match(content)
 }
 
 fn is_spdx_line(content: &str) -> bool {
-    let re = IS_SPDX_LINE.get_or_init(|| Regex::new(r"!\s*[^;]+(?:;\s*.+)?").unwrap());
+    let re = regex!(r"!\s*[^;]+(?:;\s*.+)?");
 
     re.is_match(content)
 }
 
 fn is_template_line(content: &str) -> bool {
-    let re = IS_TEMPLATE_LINE.get_or_init(|| Regex::new(r"&\s*.+").unwrap());
+    let re = regex!(r"&\s*.+");
 
     re.is_match(content)
 }
 
 fn is_identifier(content: &str) -> bool {
-    let re = IS_IDENTIFIER.get_or_init(|| Regex::new(r"^[a-z][a-z0-9_]*$").unwrap());
+    let re = regex!(r"^[a-z][a-z0-9_]*$");
     re.is_match(content)
 }
 
@@ -1328,7 +1300,7 @@ fn is_identifier(content: &str) -> bool {
 /// terminated by an end of line.
 
 fn is_signature(content: &str) -> bool {
-    let re = IS_SIGNATURE.get_or_init(|| Regex::new(r"\s*.+?\s*->\s*.+?\s*$").unwrap());
+    let re = regex!(r"\s*.+?\s*->\s*.+?\s*$");
 
     re.is_match(content)
 }
@@ -1352,8 +1324,7 @@ fn is_genus(content: &str) -> bool {
     match first {
         '[' => {
             // List pattern: [Forma] where Forma starts with uppercase
-            let re =
-                IS_GENUS_LIST.get_or_init(|| Regex::new(r"^\[\s*[A-Z][A-Za-z0-9]*\s*\]$").unwrap());
+            let re = regex!(r"^\[\s*[A-Z][A-Za-z0-9]*\s*\]$");
             re.is_match(content)
         }
         '(' => {
@@ -1364,14 +1335,12 @@ fn is_genus(content: &str) -> bool {
                 }
             }
             // Tuple pattern: (Forma, Forma, ...)
-            let re = IS_GENUS_TUPLE.get_or_init(|| {
-                Regex::new(r"^\(\s*[A-Z][A-Za-z0-9]*(\s*,\s*[A-Z][A-Za-z0-9]*)*\s*\)$").unwrap()
-            });
+            let re = regex!(r"^\(\s*[A-Z][A-Za-z0-9]*(\s*,\s*[A-Z][A-Za-z0-9]*)*\s*\)$");
             re.is_match(content)
         }
         _ => {
             // Single Forma pattern
-            let re = IS_GENUS_SINGLE.get_or_init(|| Regex::new(r"^[A-Z][A-Za-z0-9]*$").unwrap());
+            let re = regex!(r"^[A-Z][A-Za-z0-9]*$");
             re.is_match(content)
         }
     }
@@ -1462,43 +1431,43 @@ fn is_procedure_title(content: &str) -> bool {
 // I'm not sure about anchoring this one on start and end, seeing as how it
 // will be used when scanning.
 fn is_invocation(content: &str) -> bool {
-    let re = IS_INVOCATION.get_or_init(|| Regex::new(r"^\s*(<.+?>\s*(?:\(.*?\))?)\s*$").unwrap());
+    let re = regex!(r"^\s*(<.+?>\s*(?:\(.*?\))?)\s*$");
 
     re.is_match(content)
 }
 
 fn is_code_block(content: &str) -> bool {
-    let re = IS_CODE_BLOCK.get_or_init(|| Regex::new(r"\s*{.*?}").unwrap());
+    let re = regex!(r"\s*{.*?}");
 
     re.is_match(content)
 }
 
 fn is_foreach_keyword(content: &str) -> bool {
-    let re = IS_FOREACH_KEYWORD.get_or_init(|| Regex::new(r"^\s*foreach\s+\w+\s+in\s+").unwrap());
+    let re = regex!(r"^\s*foreach\s+\w+\s+in\s+");
 
     re.is_match(content)
 }
 
 fn is_repeat_keyword(content: &str) -> bool {
-    let re = IS_REPEAT_KEYWORD.get_or_init(|| Regex::new(r"^\s*repeat\s+").unwrap());
+    let re = regex!(r"^\s*repeat\s+");
 
     re.is_match(content)
 }
 
 fn is_function(content: &str) -> bool {
-    let re = IS_FUNCTION.get_or_init(|| Regex::new(r"^\s*.+?\(").unwrap());
+    let re = regex!(r"^\s*.+?\(");
 
     re.is_match(content)
 }
 
 fn is_binding(content: &str) -> bool {
-    let re = IS_BINDING.get_or_init(|| Regex::new(r"~\s+\w+\s*$").unwrap());
+    let re = regex!(r"~\s+\w+\s*$");
 
     re.is_match(content)
 }
 
 fn is_step(content: &str) -> bool {
-    let re = IS_STEP.get_or_init(|| Regex::new(r"^\s*\d+\.\s+").unwrap());
+    let re = regex!(r"^\s*\d+\.\s+");
     re.is_match(content)
 }
 
@@ -1512,28 +1481,27 @@ fn is_step(content: &str) -> bool {
 /// used to compose a number below 40 in roman numerals, as those are
 /// sub-sub-steps.
 fn is_substep_dependent(content: &str) -> bool {
-    let re = IS_SUBSTEP_DEPENDENT.get_or_init(|| Regex::new(r"^\s*[a-hj-uw-z]\.\s+").unwrap());
+    let re = regex!(r"^\s*[a-hj-uw-z]\.\s+");
     re.is_match(content)
 }
 
 fn is_substep_parallel(content: &str) -> bool {
-    let re = IS_SUBSTEP_PARALLEL.get_or_init(|| Regex::new(r"^\s*-\s+").unwrap());
+    let re = regex!(r"^\s*-\s+");
     re.is_match(content)
 }
 
 fn is_subsubstep_dependent(content: &str) -> bool {
-    let re = IS_SUBSUBSTEP_DEPENDENT.get_or_init(|| Regex::new(r"^\s*[ivx]+\.\s+").unwrap());
+    let re = regex!(r"^\s*[ivx]+\.\s+");
     re.is_match(content)
 }
 
 fn is_role_assignment(content: &str) -> bool {
-    let re = IS_ROLE_ASSIGNMENT
-        .get_or_init(|| Regex::new(r"^\s*@[a-z][a-z0-9_]*(\s*\+\s*@[a-z][a-z0-9_]*)*").unwrap());
+    let re = regex!(r"^\s*@[a-z][a-z0-9_]*(\s*\+\s*@[a-z][a-z0-9_]*)*");
     re.is_match(content)
 }
 
 fn is_enum_response(content: &str) -> bool {
-    let re = IS_ENUM_RESPONSE.get_or_init(|| Regex::new(r"^\s*'.+?'").unwrap());
+    let re = regex!(r"^\s*'.+?'");
     re.is_match(content)
 }
 


### PR DESCRIPTION
Improve performance by caching the regex::Regex objects that are allocated at runtime when  regular expression is compiled. Do this using the usual trick of caching them behind OnceLock references, but rather than a global variable per regex, use a custom `regex!` macro to put the
allocation and unwrapping in place at each call site for us instead.