### PR TITLE
Improve display of error messages

### DIFF
--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -1,12 +1,27 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TechniqueError<'i> {
     pub problem: String,
+    pub details: String,
     pub source: &'i str,
     pub offset: usize,
     pub width: Option<usize>,
 }
 
 use std::fmt;
+
+impl<'i> TechniqueError<'i> {
+    pub fn full_details(&self) -> String {
+        let n = calculate_line_number(self.source, self.offset);
+
+        let line = self
+            .source
+            .lines()
+            .nth(n)
+            .unwrap_or("<NOT FOUND>");
+
+        format!("{}\n{}: {}\n\n{}", self.problem, n + 1, line, self.details)
+    }
+}
 
 impl<'i> fmt::Display for TechniqueError<'i> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -1,39 +1,81 @@
+use std::{fmt, path::Path};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TechniqueError<'i> {
     pub problem: String,
     pub details: String,
+    pub filename: &'i Path,
     pub source: &'i str,
     pub offset: usize,
     pub width: Option<usize>,
 }
 
-use std::fmt;
-
+// Verbose detailed explanation
 impl<'i> TechniqueError<'i> {
     pub fn full_details(&self) -> String {
-        let n = calculate_line_number(self.source, self.offset);
+        let i = calculate_line_number(self.source, self.offset);
+        let j = calculate_column_number(self.source, self.offset);
 
-        let line = self
+        let code = self
             .source
             .lines()
-            .nth(n)
-            .unwrap_or("<NOT FOUND>");
+            .nth(i)
+            .unwrap_or("?");
 
-        format!("{}\n{}: {}\n\n{}", self.problem, n + 1, line, self.details)
+        let line = i + 1;
+        let column = j + 1;
+
+        let width = line
+            .to_string()
+            .len();
+        let width = 3.max(width);
+
+        format!(
+            r#"
+error: {}
+{}:{}:{}
+
+{:width$} |
+{:width$} | {}
+{:width$} | {:>j$}
+
+{}
+            "#,
+            self.problem,
+            self.filename
+                .to_string_lossy(),
+            line,
+            column,
+            ' ',
+            line,
+            code,
+            ' ',
+            '^',
+            self.details
+        )
+        .trim_ascii()
+        .to_string()
     }
 }
 
+// Concise version for internal use
 impl<'i> fmt::Display for TechniqueError<'i> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let n = calculate_line_number(self.source, self.offset);
+        let i = calculate_line_number(self.source, self.offset);
+        let j = calculate_column_number(self.source, self.offset);
 
-        let line = self
-            .source
-            .lines()
-            .nth(n)
-            .unwrap_or("<NOT FOUND>");
+        let line = i + 1;
+        let column = j + 1;
 
-        write!(f, "{}\n{}: {}", self.problem, n + 1, line)
+        write!(
+            f,
+            "error: {}:{}:{} {}",
+            self.filename
+                .to_string_lossy(),
+            line,
+            column,
+            self.problem
+        )
     }
 }
 
@@ -44,6 +86,15 @@ fn calculate_line_number(content: &str, offset: usize) -> usize {
         .bytes()
         .filter(|&b| b == b'\n')
         .count()
+}
+
+// Calculate the column number, also zero-origin for consistency.
+fn calculate_column_number(content: &str, offset: usize) -> usize {
+    let before = &content[..offset];
+    match before.rfind('\n') {
+        Some(start) => offset - start,
+        None => offset,
+    }
 }
 
 #[cfg(test)]

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -22,7 +22,7 @@ impl<'i> fmt::Display for TechniqueError<'i> {
     }
 }
 
-// This returns a zero-origin result so that it can subseequently be used for
+// This returns a zero-origin result so that it can subsequently be used for
 // splitting; for display to humans you'll have to add 1.
 fn calculate_line_number(content: &str, offset: usize) -> usize {
     content[..offset]

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,9 @@ fn main() {
 
             debug!(filename);
 
-            let content = parsing::load(&Path::new(filename));
-            let technique = parsing::parse(&content);
+            let filename = Path::new(filename);
+            let content = parsing::load(filename);
+            let technique = parsing::parse(&filename, &content);
             // TODO continue with validation of the returned technique
 
             println!("{:#?}", technique);
@@ -131,8 +132,9 @@ fn main() {
 
             debug!(filename);
 
-            let content = parsing::load(&Path::new(filename));
-            let technique = parsing::parse(&content);
+            let filename = Path::new(filename);
+            let content = parsing::load(&filename);
+            let technique = parsing::parse(&filename, &content);
 
             let result = formatting::format(&technique, wrap_width);
             print!("{}", result);

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -16,8 +16,8 @@ pub fn load(filename: &Path) -> String {
 }
 
 /// Parse text into a Technique object, or error out.
-pub fn parse(content: &str) -> Document {
-    let result = parser::parse_via_taking(content);
+pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Document<'i> {
+    let result = parser::parse_via_taking(filename, content);
 
     match result {
         Ok(document) => {
@@ -48,7 +48,7 @@ pub fn parse(content: &str) -> Document {
             document
         }
         Err(error) => {
-            eprintln!("error: {}", error.full_details());
+            eprintln!("{}", error.full_details());
             std::process::exit(1);
         }
     }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -48,7 +48,7 @@ pub fn parse(content: &str) -> Document {
             document
         }
         Err(error) => {
-            eprintln!("error: {}", error);
+            eprintln!("error: {}", error.full_details());
             std::process::exit(1);
         }
     }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -16,8 +16,10 @@ pub fn parse_via_taking(content: &str) -> Result<Document, TechniqueError> {
 }
 
 fn make_error<'i>(parser: Parser<'i>, error: ParsingError<'i>) -> TechniqueError<'i> {
+    let (problem, details) = error.message();
     TechniqueError {
-        problem: error.message(),
+        problem,
+        details,
         source: parser.original,
         offset: error.offset(),
         width: None,

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::error::*;
 use crate::language::*;
 use crate::regex::*;
@@ -476,11 +474,6 @@ impl<'i> Parser<'i> {
         let result = self.take_until(&['\n'], f);
         self.require_newline()?;
         result
-    }
-
-    #[deprecated]
-    fn entire(&self) -> &'i str {
-        self.source
     }
 
     fn is_finished(&self) -> bool {
@@ -1839,17 +1832,6 @@ impl<'i> Parser<'i> {
         })
     }
 
-    fn ensure_nonempty(&mut self) -> Result<(), ParsingError<'i>> {
-        if self
-            .source
-            .len()
-            == 0
-        {
-            return Err(ParsingError::UnexpectedEndOfInput(self.offset));
-        }
-        Ok(())
-    }
-
     /// Trim any leading whitespace (space, tab, newline) from the front of
     /// the current parser text.
     fn trim_whitespace(&mut self) {
@@ -2019,6 +2001,7 @@ fn is_identifier(content: &str) -> bool {
 ///
 /// terminated by an end of line.
 
+#[allow(unused)]
 fn is_signature(content: &str) -> bool {
     let re = regex!(r"\s*.+?\s*->\s*.+?\s*$");
 
@@ -2177,6 +2160,7 @@ fn is_code_block(content: &str) -> bool {
     re.is_match(content)
 }
 
+#[allow(unused)]
 fn is_code_inline(content: &str) -> bool {
     let content = content.trim_ascii_start();
     content.starts_with('{')
@@ -2353,12 +2337,19 @@ mod check {
     fn check_not_eof() {
         let mut input = Parser::new();
         input.initialize("Hello World");
-        assert_eq!(input.ensure_nonempty(), Ok(()));
+        assert!(
+            input
+                .source
+                .len()
+                > 0
+        );
 
         input.initialize("");
-        assert_eq!(
-            input.ensure_nonempty(),
-            Err(ParsingError::UnexpectedEndOfInput(input.offset))
+        assert!(
+            input
+                .source
+                .len()
+                > 0
         );
     }
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -2373,20 +2373,10 @@ mod check {
     fn check_not_eof() {
         let mut input = Parser::new();
         input.initialize("Hello World");
-        assert!(
-            input
-                .source
-                .len()
-                > 0
-        );
+        assert!(!input.is_finished());
 
         input.initialize("");
-        assert!(
-            input
-                .source
-                .len()
-                > 0
-        );
+        assert!(input.is_finished());
     }
 
     #[test]

--- a/tests/parsing/parser.rs
+++ b/tests/parsing/parser.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod verify {
+    use std::path::Path;
     use std::vec;
 
     use technique::language::*;
@@ -1088,8 +1089,10 @@ before_leaving :
 
     #[test]
     fn section_parsing() {
-        let result = technique::parsing::parser::parse_via_taking(trim(
-            r#"
+        let result = technique::parsing::parser::parse_via_taking(
+            Path::new(""),
+            trim(
+                r#"
 main_procedure :
 
 I. First Section
@@ -1112,7 +1115,8 @@ second_section_second_procedure :
 
 # Two dot Two
             "#,
-        ));
+            ),
+        );
 
         let document = match result {
             Ok(document) => document,
@@ -1173,8 +1177,10 @@ second_section_second_procedure :
 
     #[test]
     fn section_with_procedures_only() {
-        let result = technique::parsing::parser::parse_via_taking(trim(
-            r#"
+        let result = technique::parsing::parser::parse_via_taking(
+            Path::new(""),
+            trim(
+                r#"
 main_procedure :
 
 I. First Section
@@ -1189,7 +1195,8 @@ procedure_three : Concept -> Requirements
 
 procedure_four : Concept -> Architecture
             "#,
-        ));
+            ),
+        );
 
         let document = match result {
             Ok(document) => document,
@@ -1241,8 +1248,10 @@ procedure_four : Concept -> Architecture
 
     #[test]
     fn section_with_procedures() {
-        let result = parser::parse_via_taking(trim(
-            r#"
+        let result = parser::parse_via_taking(
+            Path::new(""),
+            trim(
+                r#"
 main_procedure :
 
 I. Concept
@@ -1261,7 +1270,8 @@ determine_architecture : Concept -> Architecture
 
 III. Implementation
             "#,
-        ));
+            ),
+        );
 
         let document = match result {
             Ok(document) => document,


### PR DESCRIPTION
When reporting errors, we now report both a succinct error message and a more detailed explanation of what it means and what good input code would look like. To that end, we enrich the details for each of the current failure modes in ParsingError and change TechniqueError to take both.

Update the display of errors to include line and column number, and a pointer to where in the failed line the problem occurred. We also emit the filename, as is conventional in compiler error messsages, which required plumbing the Path through the call stack.

Finally we have updated the check command to have an `--output` option which takes `native` to dump the AST, otherwise either exiting 1 and reporting the error, or exiting 0 indicating a pass.