### PR TITLE
Improve detection of problems with signatures

### DIFF
--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -34,8 +34,7 @@ impl<'i> TechniqueError<'i> {
 
         format!(
             r#"
-{}: {}
-{}:{}:{}
+{}: {}:{}:{} {}
 
 {:width$} {}
 {:width$} {} {}
@@ -44,12 +43,12 @@ impl<'i> TechniqueError<'i> {
 {}
             "#,
             "error".bright_red(),
-            self.problem
-                .bold(),
             self.filename
                 .to_string_lossy(),
             line,
             column,
+            self.problem
+                .bold(),
             ' ',
             '|'.bright_blue(),
             line.bright_blue(),
@@ -63,26 +62,31 @@ impl<'i> TechniqueError<'i> {
         .trim_ascii()
         .to_string()
     }
-}
 
-// Concise version for internal use
-impl<'i> fmt::Display for TechniqueError<'i> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    pub fn concise_error(&self) -> String {
         let i = calculate_line_number(self.source, self.offset);
         let j = calculate_column_number(self.source, self.offset);
 
         let line = i + 1;
         let column = j + 1;
 
-        write!(
-            f,
-            "error: {}:{}:{} {}",
+        format!(
+            "{}: {}:{}:{} {}",
+            "error".bright_red(),
             self.filename
                 .to_string_lossy(),
             line,
             column,
             self.problem
+                .bold(),
         )
+    }
+}
+
+// Concise version for internal use
+impl<'i> fmt::Display for TechniqueError<'i> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.concise_error())
     }
 }
 

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -25,7 +25,7 @@ impl<'i> TechniqueError<'i> {
             .unwrap_or("?");
 
         let line = i + 1;
-        let column = j + 1;
+        let column = j;
 
         let width = line
             .to_string()
@@ -68,7 +68,7 @@ impl<'i> TechniqueError<'i> {
         let j = calculate_column_number(self.source, self.offset);
 
         let line = i + 1;
-        let column = j + 1;
+        let column = j;
 
         format!(
             "{}: {}:{}:{} {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::value_parser;
 use clap::{Arg, ArgAction, Command};
+use owo_colors::OwoColorize;
 use std::path::Path;
 use tracing::debug;
 use tracing_subscriber;
@@ -136,6 +137,8 @@ fn main() {
             let content = parsing::load(filename);
             let technique = parsing::parse(&filename, &content);
             // TODO continue with validation of the returned technique
+
+            eprintln!("{}", "ok".bright_green());
 
             if let Output::Native = output {
                 println!("{:#?}", technique);

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,13 @@ fn main() {
 
             let filename = Path::new(filename);
             let content = parsing::load(filename);
-            let technique = parsing::parse(&filename, &content);
+            let technique = match parsing::parse(&filename, &content) {
+                Ok(document) => document,
+                Err(error) => {
+                    eprintln!("{}", error.full_details());
+                    std::process::exit(1);
+                }
+            };
             // TODO continue with validation of the returned technique
 
             eprintln!("{}", "ok".bright_green());
@@ -165,7 +171,13 @@ fn main() {
 
             let filename = Path::new(filename);
             let content = parsing::load(&filename);
-            let technique = parsing::parse(&filename, &content);
+            let technique = match parsing::parse(&filename, &content) {
+                Ok(document) => document,
+                Err(error) => {
+                    eprintln!("{}", error.concise_error());
+                    std::process::exit(1);
+                }
+            };
 
             let result = formatting::format(&technique, wrap_width);
             print!("{}", result);

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 use tracing::debug;
 
-use crate::language::{Document, Technique};
+use crate::{error::TechniqueError, language::{Document, Technique}};
 
 pub mod parser;
 mod scope;
@@ -16,7 +16,7 @@ pub fn load(filename: &Path) -> String {
 }
 
 /// Parse text into a Technique object, or error out.
-pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Document<'i> {
+pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Result<Document<'i>, TechniqueError<'i>> {
     let result = parser::parse_via_taking(filename, content);
 
     match result {
@@ -44,11 +44,11 @@ pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Document<'i> {
             } else {
                 debug!("No content found");
             }
-            document
+            Ok(document)
         }
         Err(error) => {
-            eprintln!("{}", error.full_details());
-            std::process::exit(1);
+            debug!("error: {}", error.problem);
+            Err(error)
         }
     }
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,6 +1,5 @@
 //! parser for the Technique language
 
-use owo_colors::OwoColorize;
 use std::path::Path;
 use tracing::debug;
 
@@ -45,8 +44,6 @@ pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Document<'i> {
             } else {
                 debug!("No content found");
             }
-            eprintln!("{}", "ok".bright_green());
-
             document
         }
         Err(error) => {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -209,10 +209,10 @@ doesn't have an input or result, per se.
                 .to_string(),
             ),
             ParsingError::InvalidSignature(_) => (
-                "Invalid procedure signature".to_string(),
+                "Invalid signature".to_string(),
                 r#"
-Signatures follow the pattern domain -> range, where domain and range are
-genus. Some examples:
+Procedure signatures follow the pattern domain -> range, where domain and
+range are genus. Some examples:
 
     A -> B
     (Beans, Milk) -> Coffee

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -966,7 +966,10 @@ impl<'i> Parser<'i> {
 
         let cap = match re.captures(self.source) {
             Some(c) => c,
-            None => return Err(ParsingError::InvalidSignature(self.offset)),
+            None => {
+                let arrow_offset = analyse_malformed_signature(self.source);
+                return Err(ParsingError::InvalidSignature(self.offset + arrow_offset));
+            }
         };
 
         let one = cap
@@ -1045,7 +1048,7 @@ impl<'i> Parser<'i> {
 
         let signature = match cap.get(2) {
             Some(two) => {
-                let mut inner = self.subparser(0, two.as_str());
+                let mut inner = self.subparser(two.start(), two.as_str());
                 let result = inner.read_signature()?;
                 Some(result)
             }
@@ -2128,6 +2131,30 @@ fn is_signature(content: &str) -> bool {
     re.is_match(content)
 }
 
+fn analyse_malformed_signature(content: &str) -> usize {
+    let mut offset = 0;
+    let mut count = 0;
+
+    for token in content
+        .trim_ascii()
+        .split_ascii_whitespace()
+    {
+        if count == 1 {
+            // Found second token - point to where arrow should be (between tokens)
+            return offset;
+        }
+        offset += token.len();
+        // Skip whitespace to next token
+        offset += content[offset..]
+            .chars()
+            .take_while(|c| c.is_ascii_whitespace())
+            .count();
+        count += 1;
+    }
+
+    0 // fallback
+}
+
 /// Lightweight detection function for Genus patterns. This is necessary as an
 /// adjunct to is_procedure_declaration() in order to support recognizing
 /// multi-line procedure declarations. Each of these regexes unfortunately has
@@ -2176,7 +2203,7 @@ fn is_genus(content: &str) -> bool {
     }
 }
 
-/// declarations are of the form
+/// Correct declarations are of the form
 ///
 /// ```text
 /// name : signature
@@ -2203,12 +2230,15 @@ fn is_genus(content: &str) -> bool {
 /// as above. Crucially, it must not match within a procedure body, for
 /// example it must not match " a. And now: do something" or "b. Proceed
 /// with:".
-
+///
+/// This function, however, is permissive. It identifies lines that could be
+/// intended as procedure declarations (including malformed ones) so that
+/// proper validation and error messages can be provided during the actual
+/// parsing phase.
 fn is_procedure_declaration(content: &str) -> bool {
     match content.split_once(':') {
-        Some((before, after)) => {
+        Some((before, _after)) => {
             let before = before.trim_ascii();
-            let after = after.trim_ascii();
 
             // Check if the name part is valid
             let has_valid_name = if let Some((name, params)) = before.split_once('(') {
@@ -2219,42 +2249,9 @@ fn is_procedure_declaration(content: &str) -> bool {
                 is_identifier(before)
             };
 
-            // Check content after ':' - either empty, procedure content, or valid signature
-            let has_valid_signature = if after.is_empty() {
-                true // No signature, just procedure content
-            } else {
-                // Check if the first token looks like a Genus
-                let token = after
-                    .split_whitespace()
-                    .next()
-                    .unwrap_or("");
-
-                if !is_genus(token) {
-                    // First token is not a Genus, so this is procedure content (title, description, etc.)
-                    true
-                } else {
-                    // First token is a Genus, so we expect a complete signature: Genus -> Genus
-                    // Find the arrow and extract domain and range
-                    if let Some(i) = after.find("->") {
-                        let domain = after[..i].trim_ascii();
-                        let range = after[i + 2..].trim_ascii();
-
-                        let range = if let Some(j) = range.find('\n') {
-                            &range[..j]
-                        } else {
-                            range
-                        };
-
-                        // Both parts must be valid Genus
-                        is_genus(domain) && is_genus(range)
-                    } else {
-                        // Has Genus but no arrow - malformed signature
-                        false
-                    }
-                }
-            };
-
-            has_valid_name && has_valid_signature
+            // For block isolation, we only need to check the identifier part.
+            // Actual signature validation happens during parsing.
+            has_valid_name
         }
         None => false,
     }
@@ -2603,7 +2600,10 @@ mod check {
         );
 
         let content = "f : B";
-        assert!(!is_procedure_declaration(content));
+        // we still need to detect procedure declarations with malformed
+        // signatures; the user's intent will be to declare a procedure though
+        // it will fail validation in the parser shortly after.
+        assert!(is_procedure_declaration(content));
 
         let content = r#"
     connectivity_check(e,s) : LocalEnvironment, TargetService -> NetworkHealth

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -2666,6 +2666,55 @@ mod check {
     }
 
     #[test]
+    fn multiline_signature_parsing() {
+        let mut input = Parser::new();
+        let content = r#"
+making_coffee :
+   Ingredients
+     -> Coffee
+                    "#
+        .trim_ascii();
+
+        input.initialize(content);
+        let result = input.parse_procedure_declaration();
+
+        assert_eq!(
+            result,
+            Ok((
+                Identifier("making_coffee"),
+                None,
+                Some(Signature {
+                    domain: Genus::Single(Forma("Ingredients")),
+                    range: Genus::Single(Forma("Coffee"))
+                })
+            ))
+        );
+
+        // Test complex multiline signature with parameters and tuple
+        let content = r#"
+making_coffee(b, m) :
+       (Beans, Milk)
+         -> Coffee
+                    "#
+        .trim_ascii();
+
+        input.initialize(content);
+        let result = input.parse_procedure_declaration();
+
+        assert_eq!(
+            result,
+            Ok((
+                Identifier("making_coffee"),
+                Some(vec![Identifier("b"), Identifier("m")]),
+                Some(Signature {
+                    domain: Genus::Tuple(vec![Forma("Beans"), Forma("Milk")]),
+                    range: Genus::Single(Forma("Coffee"))
+                })
+            ))
+        );
+    }
+
+    #[test]
     fn character_delimited_blocks() {
         let mut input = Parser::new();
         input.initialize("{ todo() }");


### PR DESCRIPTION
Further improvements to the detection and output of errors.

The "ok" string is now only printed from the _technique check_ command; if running _format_ then it just validates silently before outputting the formatted code.

Filename, line, and columns are now printed consistently in error messages be they concise or full.

A significant improvement is the handling of mistakes made by the user when writing signatures and when those signatures are spread over multiple lines. Both were failing, the first with InvalidProcedure rather than the more specific InvalidSignature you'd expect and the error offset was not pointing to the mistake in the signature.

