### PR TITLE
Parse and format Quantities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,8 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = [ "env-filter" ] }
 
 [build-dependencies]
+
+[profile.release]
+debug = "limited"
+strip = true
+lto = true

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2002-2024 Athae Eredh Siniath and Others
+Copyright © 2002-2025 Athae Eredh Siniath and Others
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -25,7 +25,7 @@ impl<'i> TechniqueError<'i> {
             .unwrap_or("?");
 
         let line = i + 1;
-        let column = j;
+        let column = j + 1;
 
         let width = line
             .to_string()
@@ -38,7 +38,7 @@ impl<'i> TechniqueError<'i> {
 
 {:width$} {}
 {:width$} {} {}
-{:width$} {} {:>j$}
+{:width$} {} {:>column$}
 
 {}
             "#,
@@ -68,7 +68,7 @@ impl<'i> TechniqueError<'i> {
         let j = calculate_column_number(self.source, self.offset);
 
         let line = i + 1;
-        let column = j;
+        let column = j + 1;
 
         format!(
             "{}: {}:{}:{} {}",

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -822,7 +822,7 @@ impl Formatter {
     fn append_numeric(&mut self, numeric: &Numeric) {
         match numeric {
             Numeric::Integral(num) => self.append(Syntax::Numeric, &num.to_string()),
-            Numeric::Scientific(_) => todo!(),
+            Numeric::Scientific(quantity) => self.append(Syntax::Numeric, &quantity.to_string()),
         }
     }
 

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -1,5 +1,6 @@
 // Types representing the Technique procedures language
 
+mod quantity;
 mod types;
 
 // Re-export all public symbols

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -4,4 +4,5 @@ mod quantity;
 mod types;
 
 // Re-export all public symbols
+pub use quantity::*;
 pub use types::*;

--- a/src/language/quantity.rs
+++ b/src/language/quantity.rs
@@ -1,0 +1,278 @@
+//! Quantity types and parsing for scientific measurements with uncertainty and units
+
+use crate::regex::*;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Quantity<'i> {
+    pub mantissa: Decimal,
+    pub uncertainty: Option<Decimal>,
+    pub magnitude: Option<i8>,
+    pub symbol: &'i str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Decimal {
+    pub number: i64,
+    pub precision: u8,
+}
+
+/// Parse a string as a Quantity if it matches the expected format
+pub fn parse_quantity(input: &str) -> Option<Quantity> {
+    // Look for patterns that indicate a quantity:
+    // - decimal number followed by space and unit symbol
+    // - decimal number with uncertainty (±)
+    // - decimal number with magnitude (× or x)
+    let re = regex!(r"^\s*(-?[0-9]+(?:\.[0-9]+)?)\s*(.*)$");
+
+    let cap = re.captures(input)?;
+    let one = cap.get(1)?;
+    let two = cap.get(2)?;
+
+    // Parse the mantissa as a decimal
+    let mantissa = parse_decimal(one.as_str())?;
+
+    // Parse the remainder for uncertainty, magnitude, and symbol
+    let mut remainder = two
+        .as_str()
+        .trim_ascii();
+
+    let mut uncertainty = None;
+    let mut magnitude = None;
+
+    let re = regex!(r"^(?:±|\+/-)\s*([0-9]+(?:\.[0-9]+)?)\s*(.*)$");
+
+    // Parse uncertainty (± or +/-)
+    if let Some(cap) = re.captures(remainder) {
+        uncertainty = Some(parse_decimal(
+            cap.get(1)?
+                .as_str(),
+        )?);
+        remainder = cap
+            .get(2)?
+            .as_str();
+    }
+
+    // Parse magnitude (× 10^n or x 10^n)
+
+    let re = regex!(r"^(?:×|x|\*)\s*10(?:\^(-?[0-9]+)|([⁰¹²³⁴⁵⁶⁷⁸⁹⁻]+))\s*(.*)$");
+    if let Some(cap) = re.captures(remainder) {
+        let exp_str = if let Some(ascii_exp) = cap.get(1) {
+            ascii_exp.as_str()
+        } else if let Some(super_exp) = cap.get(2) {
+            // Convert superscript to regular digits
+            &convert_superscript(super_exp.as_str())
+        } else {
+            return None;
+        };
+
+        magnitude = Some(
+            exp_str
+                .parse()
+                .ok()?,
+        );
+        remainder = cap
+            .get(3)?
+            .as_str();
+    }
+
+    // The rest should be the unit symbol
+    let symbol = remainder.trim_ascii();
+    if symbol.is_empty() {
+        return None; // Quantities must have units
+    }
+
+    // Validate unit symbol contains only allowed characters: [a-zA-Z°/]
+    let re = regex!(r"^[a-zA-Z°/]+$");
+    if !re.is_match(symbol) {
+        return None;
+    }
+
+    Some(Quantity {
+        mantissa,
+        uncertainty,
+        magnitude,
+        symbol,
+    })
+}
+
+fn parse_decimal(input: &str) -> Option<Decimal> {
+    if let Some(dot_pos) = input.find('.') {
+        // Has decimal point
+        let whole_part = &input[..dot_pos];
+        let frac_part = &input[dot_pos + 1..];
+
+        let whole: i64 = whole_part
+            .parse()
+            .ok()?;
+        let frac: i64 = frac_part
+            .parse()
+            .ok()?;
+        let precision = frac_part.len() as u8;
+
+        // Combine whole and fractional parts
+        let number = whole * 10_i64.pow(precision as u32) + if whole < 0 { -frac } else { frac };
+
+        Some(Decimal { number, precision })
+    } else {
+        // Integer
+        let number: i64 = input
+            .parse()
+            .ok()?;
+        Some(Decimal {
+            number,
+            precision: 0,
+        })
+    }
+}
+
+fn convert_superscript(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| match c {
+            '⁰' => '0',
+            '¹' => '1',
+            '²' => '2',
+            '³' => '3',
+            '⁴' => '4',
+            '⁵' => '5',
+            '⁶' => '6',
+            '⁷' => '7',
+            '⁸' => '8',
+            '⁹' => '9',
+            '⁻' => '-',
+            _ => c,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_quantities() {
+        // Simple quantity with unit
+        let result = parse_quantity("4 kg").unwrap();
+        assert_eq!(
+            result.mantissa,
+            Decimal {
+                number: 4,
+                precision: 0
+            }
+        );
+        assert_eq!(result.uncertainty, None);
+        assert_eq!(result.magnitude, None);
+        assert_eq!(result.symbol, "kg");
+    }
+
+    #[test]
+    fn parse_decimal_quantities() {
+        let result = parse_quantity("5.9722 kg").unwrap();
+        assert_eq!(
+            result.mantissa,
+            Decimal {
+                number: 59722,
+                precision: 4
+            }
+        );
+        assert_eq!(result.symbol, "kg");
+    }
+
+    #[test]
+    fn parse_quantity_with_uncertainty() {
+        let result = parse_quantity("4 ± 1 kg").unwrap();
+        assert_eq!(
+            result.mantissa,
+            Decimal {
+                number: 4,
+                precision: 0
+            }
+        );
+        assert_eq!(
+            result.uncertainty,
+            Some(Decimal {
+                number: 1,
+                precision: 0
+            })
+        );
+        assert_eq!(result.symbol, "kg");
+    }
+
+    #[test]
+    fn parse_quantity_with_magnitude() {
+        let result = parse_quantity("4 × 10^2 kg").unwrap();
+        assert_eq!(
+            result.mantissa,
+            Decimal {
+                number: 4,
+                precision: 0
+            }
+        );
+        assert_eq!(result.magnitude, Some(2));
+        assert_eq!(result.symbol, "kg");
+    }
+
+    #[test]
+    fn parse_full_quantity() {
+        let result = parse_quantity("5.9722 ± 0.0006 × 10^24 kg").unwrap();
+        assert_eq!(
+            result.mantissa,
+            Decimal {
+                number: 59722,
+                precision: 4
+            }
+        );
+        assert_eq!(
+            result.uncertainty,
+            Some(Decimal {
+                number: 6,
+                precision: 4
+            })
+        );
+        assert_eq!(result.magnitude, Some(24));
+        assert_eq!(result.symbol, "kg");
+    }
+
+    #[test]
+    fn parse_arbitrary_units() {
+        assert_eq!(
+            parse_quantity("3 breadsticks")
+                .unwrap()
+                .symbol,
+            "breadsticks"
+        );
+        assert_eq!(
+            parse_quantity("42 widgets")
+                .unwrap()
+                .symbol,
+            "widgets"
+        );
+        assert_eq!(
+            parse_quantity("15 m/s")
+                .unwrap()
+                .symbol,
+            "m/s"
+        );
+        assert_eq!(
+            parse_quantity("20 °C")
+                .unwrap()
+                .symbol,
+            "°C"
+        );
+    }
+
+    #[test]
+    fn parse_superscript_magnitude() {
+        let result = parse_quantity("6.022 × 10²³ mol").unwrap();
+        assert_eq!(result.magnitude, Some(23));
+        assert_eq!(result.symbol, "mol");
+    }
+
+    #[test]
+    fn invalid_quantities() {
+        assert!(parse_quantity("42").is_none()); // No units
+        assert!(parse_quantity("kg").is_none()); // No number
+        assert!(parse_quantity("4 kg-meters").is_none()); // Invalid unit chars
+        assert!(parse_quantity("4 kg_squared").is_none()); // Invalid unit chars
+    }
+}

--- a/src/language/quantity.rs
+++ b/src/language/quantity.rs
@@ -342,8 +342,15 @@ mod tests {
     fn invalid_quantities() {
         assert!(parse_quantity("42").is_none()); // No units
         assert!(parse_quantity("kg").is_none()); // No number
-        assert!(parse_quantity("4 kg-meters").is_none()); // Invalid unit chars
-        assert!(parse_quantity("4 kg_squared").is_none()); // Invalid unit chars
+        assert!(parse_quantity("4 kg-meters").is_none()); // Invalid unit chars (hyphen)
+        assert!(parse_quantity("4 kg_squared").is_none()); // Invalid unit chars (underscore)
+        assert!(parse_quantity("4 × 11^2 kg").is_none()); // Invalid magnitude base (not 10)
+        assert!(parse_quantity("4 × kg").is_none()); // Missing magnitude
+        assert!(parse_quantity("4 ± kg").is_none()); // Missing uncertainty value
+        assert!(parse_quantity("4 k g").is_none()); // Space in unit symbol
+        assert!(parse_quantity("4 ± 1.5").is_none()); // No units after uncertainty
+        assert!(parse_quantity("").is_none()); // Empty string
+        assert!(parse_quantity("   ").is_none()); // Just whitespace
     }
 
     #[test]

--- a/src/language/quantity.rs
+++ b/src/language/quantity.rs
@@ -95,7 +95,7 @@ pub fn parse_quantity(input: &str) -> Option<Quantity> {
     })
 }
 
-fn parse_decimal(input: &str) -> Option<Decimal> {
+pub fn parse_decimal(input: &str) -> Option<Decimal> {
     if let Some(dot_pos) = input.find('.') {
         // Has decimal point
         let whole_part = &input[..dot_pos];
@@ -125,7 +125,8 @@ fn parse_decimal(input: &str) -> Option<Decimal> {
     }
 }
 
-fn convert_superscript(input: &str) -> String {
+/// Convert Unicode superscript characters to ASCII digits
+pub fn convert_superscript(input: &str) -> String {
     input
         .chars()
         .map(|c| match c {

--- a/src/language/quantity.rs
+++ b/src/language/quantity.rs
@@ -1,5 +1,5 @@
 //! Quantity types and parsing for scientific measurements with uncertainty and units
-//! 
+//!
 //! A Quantity is an amount, possibly with uncertainty, at the magnitude if
 //! given, of the units specified.
 //!

--- a/src/language/quantity.rs
+++ b/src/language/quantity.rs
@@ -1,4 +1,24 @@
 //! Quantity types and parsing for scientific measurements with uncertainty and units
+//! 
+//! A Quantity is an amount, possibly with uncertainty, at the magnitude if
+//! given, of the units specified.
+//!
+//! Valid Quantities include:
+//!
+//! 149 kg
+//! 5.9722 × 10²⁴ kg
+//! 5.9722 ± 0.0006 kg
+//! 5.9722 ± 0.0006 × 10²⁴ kg
+//!
+//! More conventional ASCII symbol characters are also supported when writing
+//! Quantity values in a Technique file:
+//!
+//! 5.9722 * 10^24 kg
+//! 5.9722 +/- 0.0006 kg
+//! 5.9722 +/- 0.0006 × 10^24 kg
+//!
+//! The parser and validation code has considerable flexibility to handle
+//! various input formats.
 
 use crate::regex::*;
 use std::fmt::{self, Display};

--- a/src/language/types.rs
+++ b/src/language/types.rs
@@ -209,25 +209,7 @@ pub enum Numeric<'i> {
     Scientific(Quantity<'i>),
 }
 
-// A Quantity is an amount, possibly with uncertainty, at the magnitude if
-// given, of the units specified.
-//
-// Valid Quantities include:
-//
-// 149 kg
-// 5.9722 × 10²⁴ kg"
-// 5.9722 ± 0.0006 kg
-// 5.9722 ± 0.0006 × 10²⁴ kg
-//
-// More conventional ASCII symbol characters are also supported when writing
-// Quantity values in a Technique file:
-//
-// 5.9722 * 10^24 kg"
-// 5.9722 +/- 0.0006 kg
-// 5.9722 +/- 0.0006 × 10^24 kg
-//
-// so the parser and validation code has to have considerable flexibility.
-pub use crate::language::quantity::{Decimal, Quantity};
+pub use crate::language::quantity::Quantity;
 
 // the validate functions all need to have start and end anchors, which seems
 // like it should be abstracted away.

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -420,6 +420,17 @@ Numeric literals can be integers:
     42
     -123
     0
+
+Or quantities with units:
+
+    84.2 kg
+    5.9722 ± 0.0006 × 10²⁴ kg
+    16.1 ± 1.5 °C
+    1.00001742096 yr
+    100 μg
+
+For ease of writing you can use +/- for uncertainty, * for multiplying the
+magnitude, and ^ for the exponent.
                 "#
                 .trim_ascii()
                 .to_string(),

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -2490,7 +2490,7 @@ fn malformed_response_pattern(content: &str) -> bool {
 
 fn is_numeric(content: &str) -> bool {
     let integral = regex!(r"^\s*-?[0-9]+(\.[0-9]+)?\s*$");
-    let scientific = regex!(r"^\s*-?[0-9]+(\.[0-9]+)?(\s*[a-zA-Z°μ]|\s*±|\s*×|\s*x\s*10)");
+    let scientific = regex!(r"^\s*-?[0-9]+(\.[0-9]+)?(\s*[a-zA-Z°/μ]|\s*±|\s*\+/-|\s*×|\s*x\s*10|\s*\*\s*10|\*\s*10)");
 
     integral.is_match(content) || scientific.is_match(content)
 }


### PR DESCRIPTION
The last thing remaining needing support from the v0 version of the language was the Quantity type, whereby numeric values can have uncertainty, magnitude, and units, for example

    5.9722 ± 0.0006 × 10²⁴ kg

We add support in the parser for detecting quantity numericals, and appropriate code for presenting them nicely when formatting output.

It also turned out that we weren't accounting for the width of Unicode characters when printing error messages. That is fixed, along with ensuring that the caret points to the best location relative to where the problem is.