### PR TITLE
Support places in Attribute scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "technique"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "technique"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "A domain specific language for procedures."
 authors = [ "Andrew Cowie" ]

--- a/examples/golden/ManyAttributes.t
+++ b/examples/golden/ManyAttributes.t
@@ -1,0 +1,30 @@
+% technique v1
+
+making_coffee :
+
+These are the steps.
+
+    1.  First
+        @chef
+            -   First sub task
+            -   Second sub task
+    2.  Second
+        @chef + @barista
+            -   Third sub task
+            -   Fourth sub task
+    3.  Third
+        ^kitchen
+            -   Fifth sub task
+            -   Sixth sub task
+    4.  Four
+        ^kitchen + ^bathroom
+            -   Seventh sub task
+            -   Eighth sub task
+    5.  Five
+        @chef + ^bathroom
+            -   Ninth sub task
+            -   Tenth sub task
+    6.  Six
+        ^kitchen + @barista
+            -   Ninth sub task
+            -   Tenth sub task

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -866,7 +866,7 @@ impl<'i> Formatter<'i> {
                     self.add_fragment_reference(Syntax::Attribute, name.0);
                 }
                 Attribute::Place(name) => {
-                    self.add_fragment_reference(Syntax::Attribute, "#");
+                    self.add_fragment_reference(Syntax::Attribute, "^");
                     self.add_fragment_reference(Syntax::Attribute, name.0);
                 }
             }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -765,7 +765,7 @@ impl<'i> Parser<'i> {
                     } else if is_code_block(content) {
                         let expression = outer.read_code_block()?;
                         elements.push(Element::CodeBlock(expression));
-                    } else if is_role_assignment(content) {
+                    } else if is_attribute_assignment(content) {
                         let attribute_block = outer.read_attribute_scope()?;
                         elements.push(Element::Steps(vec![attribute_block]));
                     } else if is_step(content) {
@@ -796,14 +796,14 @@ impl<'i> Parser<'i> {
                                     && !is_procedure_title(line)
                                     && !is_code_block(line)
                                     && !malformed_step_pattern(line)
-                                    && !is_role_assignment(line)
+                                    && !is_attribute_assignment(line)
                             },
                             |line| {
                                 is_step(line)
                                     || is_procedure_title(line)
                                     || is_code_block(line)
                                     || malformed_step_pattern(line)
-                                    || is_role_assignment(line)
+                                    || is_attribute_assignment(line)
                             },
                             |inner| {
                                 let content = inner.source;
@@ -1672,7 +1672,7 @@ impl<'i> Parser<'i> {
                     || is_substep_dependent(line)
                     || is_substep_parallel(line)
                     || is_subsubstep_dependent(line)
-                    || is_role_assignment(line)
+                    || is_attribute_assignment(line)
                     || is_enum_response(line)
                     || malformed_step_pattern(line)
                     || malformed_response_pattern(line)
@@ -1972,7 +1972,7 @@ impl<'i> Parser<'i> {
 
             let content = self.source;
 
-            if is_role_assignment(content) {
+            if is_attribute_assignment(content) {
                 let block = self.read_attribute_scope()?;
                 scopes.push(block);
             } else if is_substep_dependent(content) {
@@ -2425,6 +2425,16 @@ fn is_numeric_quantity(content: &str) -> bool {
 fn is_string_literal(content: &str) -> bool {
     let re = regex!(r#"^\s*".*"\s*$"#);
     re.is_match(content)
+}
+
+fn is_place_assignment(input: &str) -> bool {
+    input
+        .trim_ascii_start()
+        .starts_with('^')
+}
+
+fn is_attribute_assignment(input: &str) -> bool {
+    is_role_assignment(input) || is_place_assignment(input)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We had the notion of both roles and places in Attributes in Technique v0, but so far in v1 we'd only implemented role Attributes with the `@role` notation. This branch adds `^place`, using the caret we're now using as the marker for place Attributes.