### PR TITLE
Fix parsing of documents with only top-level Sections

### DIFF
--- a/examples/golden/Bedtime.t
+++ b/examples/golden/Bedtime.t
@@ -1,0 +1,35 @@
+% technique v1
+! Private; © 2025 My Lovely Family
+& childrens-task-list
+
+I. Before school
+
+    1.  Drink glass of water
+    2.  Eat breakfast
+    3.  Put dishes into sink
+    4.  Get changed
+    5.  Pack school bag
+    6.  Clean teeth
+    7.  Shoes on, wait by front door!
+
+II. After school
+
+    1.  Shower
+    2.  Get changed into home clothes
+    3.  Bring lunchbox to kitchen
+    4.  Put dirty school clothes at washing machine
+    5.  Turn on heater
+    6.  Homework (as required)
+
+III. Dinner
+
+    1.  Set table
+    2.  Eat dinner
+    3.  Put dishes into dishwasher
+
+IV. Bedtime
+
+    1.  Get changed into pyjamas
+    2.  Clean teeth
+    3.  Read story
+    4.  Into bed!

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -220,11 +220,12 @@ impl<'i> Formatter<'i> {
     }
 
     fn switch_syntax(&mut self, new_syntax: Syntax) {
-        if !self.buffer.is_empty() {
-            self.fragments.push((
-                self.current,
-                Cow::Owned(std::mem::take(&mut self.buffer)),
-            ));
+        if !self
+            .buffer
+            .is_empty()
+        {
+            self.fragments
+                .push((self.current, Cow::Owned(std::mem::take(&mut self.buffer))));
         }
         self.current = new_syntax;
     }
@@ -234,11 +235,12 @@ impl<'i> Formatter<'i> {
     }
 
     pub fn flush_current(&mut self) {
-        if !self.buffer.is_empty() {
-            self.fragments.push((
-                self.current,
-                Cow::Owned(std::mem::take(&mut self.buffer)),
-            ));
+        if !self
+            .buffer
+            .is_empty()
+        {
+            self.fragments
+                .push((self.current, Cow::Owned(std::mem::take(&mut self.buffer))));
         }
     }
 
@@ -1247,7 +1249,10 @@ impl<'a, 'i> Line<'a, 'i> {
 
     fn wrap_line(&mut self) {
         // Emit all current fragments to the output
-        for (syntax, content) in self.current.drain(..) {
+        for (syntax, content) in self
+            .current
+            .drain(..)
+        {
             self.output
                 .add_fragment(syntax, content);
         }
@@ -1266,7 +1271,10 @@ impl<'a, 'i> Line<'a, 'i> {
             .is_empty()
         {
             // Emit all current fragments to the output
-            for (syntax, content) in self.current.drain(..) {
+            for (syntax, content) in self
+                .current
+                .drain(..)
+            {
                 self.output
                     .add_fragment(syntax, content);
             }

--- a/src/formatting/formatter.rs
+++ b/src/formatting/formatter.rs
@@ -410,6 +410,11 @@ impl<'i> Formatter<'i> {
     fn format_technique(&mut self, technique: &'i Technique) {
         match technique {
             Technique::Steps(steps) => {
+                // if a header has already been added,
+                // separate the upcoming steps with a blank line.
+                if !self.is_empty() {
+                    self.append_char('\n');
+                }
                 self.append_steps(steps);
             }
             Technique::Procedures(procedures) => {


### PR DESCRIPTION
Encountered a nasty bug that a document with only top-level Sections, which by design is a valid and admissible Technique (and is even how `struct Technique` is defined) was not being parsed but worse was being silently discarded.

Fixed an omission in the formatter where sections were not being preceded by a blank line.

Added an example to the golden tests to enforce this remaining correct in the future.