### PR TITLE
Collect and display all detected errors in an input document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "technique"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "owo-colors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "cfg-if"
@@ -75,18 +75,18 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -149,9 +149,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "matchers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "technique"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A domain specific language for procedures."
 authors = [ "Andrew Cowie" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,13 @@ fn main() {
             let technique = match parsing::parse(&filename, &content) {
                 Ok(document) => document,
                 Err(errors) => {
-                    for error in errors {
+                    for (i, error) in errors
+                        .iter()
+                        .enumerate()
+                    {
+                        if i > 0 {
+                            eprintln!();
+                        }
                         eprintln!(
                             "{}",
                             problem::full_parsing_error(&error, &filename, &content, &Terminal)
@@ -213,12 +219,23 @@ fn main() {
             let technique = match parsing::parse(&filename, &content) {
                 Ok(document) => document,
                 Err(errors) => {
-                    for error in errors {
+                    for (i, error) in errors
+                        .iter()
+                        .enumerate()
+                    {
+                        if i > 0 {
+                            eprintln!();
+                        }
                         eprintln!(
                             "{}",
                             problem::concise_parsing_error(&error, &filename, &content, &Terminal)
                         );
                     }
+
+                    eprintln!(
+                        "\nUnable to parse input file. Try `technique check {}` for details.",
+                        &filename.to_string_lossy()
+                    );
                     std::process::exit(1);
                 }
             };
@@ -266,7 +283,14 @@ fn main() {
                     // into the PDF document rather than crashing here. We'll
                     // see in the future.
 
-                    for error in errors {
+                    for (i, error) in errors
+                        .iter()
+                        .enumerate()
+                    {
+                        if i > 0 {
+                            eprintln!();
+                        }
+
                         eprintln!(
                             "{}",
                             problem::concise_parsing_error(&error, &filename, &content, &Terminal)

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,16 +160,17 @@ fn main() {
                     std::process::exit(1);
                 }
             };
-            let technique = match parsing::parse(&filename, &content) {
-                Ok(document) => document,
-                Err(error) => {
+            let result = parsing::parser::parse_with_recovery(&filename, &content);
+            if result.has_errors() {
+                for error in &result.errors {
                     eprintln!(
                         "{}",
-                        problem::full_parsing_error(&error, &filename, &content, &Terminal)
+                        problem::full_parsing_error(error, &filename, &content, &Terminal)
                     );
-                    std::process::exit(1);
                 }
-            };
+                std::process::exit(1);
+            }
+            let technique = result.document;
             // TODO continue with validation of the returned technique
 
             eprintln!("{}", "ok".bright_green());

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,17 +160,20 @@ fn main() {
                     std::process::exit(1);
                 }
             };
-            let result = parsing::parser::parse_with_recovery(&filename, &content);
-            if result.has_errors() {
-                for error in &result.errors {
-                    eprintln!(
-                        "{}",
-                        problem::full_parsing_error(error, &filename, &content, &Terminal)
-                    );
+
+            let technique = match parsing::parse(&filename, &content) {
+                Ok(document) => document,
+                Err(errors) => {
+                    for error in errors {
+                        eprintln!(
+                            "{}",
+                            problem::full_parsing_error(&error, &filename, &content, &Terminal)
+                        );
+                    }
+                    std::process::exit(1);
                 }
-                std::process::exit(1);
-            }
-            let technique = result.document;
+            };
+
             // TODO continue with validation of the returned technique
 
             eprintln!("{}", "ok".bright_green());
@@ -206,13 +209,16 @@ fn main() {
                     std::process::exit(1);
                 }
             };
+
             let technique = match parsing::parse(&filename, &content) {
                 Ok(document) => document,
-                Err(error) => {
-                    eprintln!(
-                        "{}",
-                        problem::concise_parsing_error(&error, &filename, &content, &Terminal)
-                    );
+                Err(errors) => {
+                    for error in errors {
+                        eprintln!(
+                            "{}",
+                            problem::concise_parsing_error(&error, &filename, &content, &Terminal)
+                        );
+                    }
                     std::process::exit(1);
                 }
             };
@@ -252,16 +258,20 @@ fn main() {
                     std::process::exit(1);
                 }
             };
+
             let technique = match parsing::parse(&filename, &content) {
                 Ok(document) => document,
-                Err(error) => {
+                Err(errors) => {
                     // It is possible that we will want to render the error
                     // into the PDF document rather than crashing here. We'll
                     // see in the future.
-                    eprintln!(
-                        "{}",
-                        problem::full_parsing_error(&error, &filename, &content, &Terminal)
-                    );
+
+                    for error in errors {
+                        eprintln!(
+                            "{}",
+                            problem::concise_parsing_error(&error, &filename, &content, &Terminal)
+                        );
+                    }
                     std::process::exit(1);
                 }
             };

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -35,9 +35,13 @@ pub fn load(filename: &Path) -> Result<String, LoadingError> {
     }
 }
 
-/// Parse text into a Technique object, or error out.
-pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Result<Document<'i>, ParsingError<'i>> {
-    let result = parser::parse_via_taking(filename, content);
+/// Parse text into a Document object, or return the list of errors
+/// encountered.
+pub fn parse<'i>(
+    filename: &'i Path,
+    content: &'i str,
+) -> Result<Document<'i>, Vec<ParsingError<'i>>> {
+    let result = parser::parse_with_recovery(filename, content);
 
     match result {
         Ok(document) => {
@@ -66,9 +70,9 @@ pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Result<Document<'i>, P
             }
             Ok(document)
         }
-        Err(error) => {
-            debug!("error: {:?}", error);
-            Err(error)
+        Err(errors) => {
+            debug!("errors: {}", errors.len());
+            Err(errors)
         }
     }
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -37,10 +37,7 @@ pub fn load(filename: &Path) -> Result<String, LoadingError> {
 
 /// Parse text into a Document object, or return the list of errors
 /// encountered.
-pub fn parse<'i>(
-    filename: &'i Path,
-    content: &'i str,
-) -> Result<Document<'i>, Vec<ParsingError<'i>>> {
+pub fn parse<'i>(filename: &'i Path, content: &'i str) -> Result<Document<'i>, Vec<ParsingError>> {
     let result = parser::parse_with_recovery(filename, content);
 
     match result {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -4460,6 +4460,41 @@ echo test
     }
 
     #[test]
+    fn test_multiple_error_collection() {
+        use std::path::Path;
+
+        // Create a string with 3 procedures: 2 with errors and 1 valid
+        let content = r#"
+broken_proc1 : A ->
+    # This procedure has incomplete signature
+
+    1. Do something
+
+valid_proc : A -> B
+    # This is a valid procedure
+
+    1. Valid step
+    2. Another valid step
+
+broken_proc2 : -> B
+    # This procedure has incomplete signature (missing domain)
+
+    1. Do something else
+        "#;
+
+        let result = parse_with_recovery(Path::new("test.t"), content);
+
+        // Assert that there are at least 2 errors (from the broken procedures)
+        match result {
+            Ok(_) => panic!("Result should have errors"),
+            Err(errors) => {
+                let l = errors.len();
+                assert!(l >= 2, "Should have at least 2 errors, got {}", l)
+            }
+        };
+    }
+
+    #[test]
     fn multiline_code_inline() {
         let mut input = Parser::new();
 

--- a/src/problem/format.rs
+++ b/src/problem/format.rs
@@ -5,7 +5,7 @@ use technique::{formatting::Render, language::LoadingError, parsing::parser::Par
 
 /// Format a parsing error with full details including source code context
 pub fn full_parsing_error<'i>(
-    error: &ParsingError<'i>,
+    error: &ParsingError,
     filename: &'i Path,
     source: &'i str,
     renderer: &impl Render,
@@ -58,7 +58,7 @@ pub fn full_parsing_error<'i>(
 
 /// Format a parsing error with concise single-line output
 pub fn concise_parsing_error<'i>(
-    error: &ParsingError<'i>,
+    error: &ParsingError,
     filename: &'i Path,
     source: &'i str,
     renderer: &impl Render,

--- a/src/problem/messages.rs
+++ b/src/problem/messages.rs
@@ -2,10 +2,7 @@ use crate::problem::Present;
 use technique::{formatting::Render, language::*, parsing::parser::ParsingError};
 
 /// Generate problem and detail messages for parsing errors using AST construction
-pub fn generate_error_message<'i>(
-    error: &ParsingError<'i>,
-    renderer: &dyn Render,
-) -> (String, String) {
+pub fn generate_error_message<'i>(error: &ParsingError, renderer: &dyn Render) -> (String, String) {
     match error {
         ParsingError::IllegalParserState(_) => (
             "Illegal parser state".to_string(),

--- a/src/problem/messages.rs
+++ b/src/problem/messages.rs
@@ -133,6 +133,7 @@ Technique. Common templates include {}, {}, and
                     r#"
 Identifiers must start with a lowercase letter and contain only lower case
 letters, numbers, and underscores. Valid examples include:
+
     {}
     {}
     {}

--- a/src/problem/messages.rs
+++ b/src/problem/messages.rs
@@ -35,6 +35,16 @@ there was no more input remaining in the current scope.
             .trim_ascii()
             .to_string(),
         ),
+        ParsingError::UnclosedInterpolation(_) => (
+            "Unclosed string interpolation".to_string(),
+            r#"
+Every '{' that starts an interpolation within a string must have a
+corresponding '}' to mark where the interpolation ends and the string
+literal resumes.
+            "#
+            .trim_ascii()
+            .to_string(),
+        ),
         ParsingError::InvalidHeader(_) => {
             // Format the sample metadata using the same code as the formatter
             let mut formatted_example = String::new();

--- a/tests/broken/BadDeclaration.tq
+++ b/tests/broken/BadDeclaration.tq
@@ -1,1 +1,3 @@
 making_coffee : Ingredients Coffee
+
+makingCoffee :

--- a/tests/parsing/errors.rs
+++ b/tests/parsing/errors.rs
@@ -1,24 +1,28 @@
 #[cfg(test)]
 mod syntax {
-    use technique::parsing::parser::{Parser, ParsingError};
+    use std::path::Path;
+    use technique::parsing::parser::{parse_with_recovery, ParsingError};
 
     /// Helper function to check if parsing produces the expected error type
     fn expect_error(content: &str, expected: ParsingError) {
-        let mut input = Parser::new();
-        input.initialize(content);
-
-        let result = input.read_procedure();
+        let result = parse_with_recovery(Path::new("test.tq"), content);
         match result {
             Ok(_) => panic!(
                 "Expected parsing to fail, but it succeeded for input: {}",
                 content
             ),
-            Err(error) => {
-                // Compare error types by discriminant
-                if std::mem::discriminant(&error) != std::mem::discriminant(&expected) {
+            Err(errors) => {
+                // Check if any error matches the expected type
+                let found_expected = errors
+                    .iter()
+                    .any(|error| {
+                        std::mem::discriminant(error) == std::mem::discriminant(&expected)
+                    });
+
+                if !found_expected {
                     panic!(
                         "Expected error type like {:?} but got: {:?} for input '{}'",
-                        expected, error, content
+                        expected, errors, content
                     );
                 }
             }
@@ -120,7 +124,7 @@ making_coffee : Ingredients Coffee
 making_coffee Ingredients -> Coffee
             "#
             .trim_ascii(),
-            ParsingError::InvalidDeclaration(0),
+            ParsingError::Unrecognized(0),
         );
     }
 

--- a/tests/parsing/errors.rs
+++ b/tests/parsing/errors.rs
@@ -36,7 +36,7 @@ mod syntax {
 Making_Coffee : Ingredients -> Coffee
             "#
             .trim_ascii(),
-            ParsingError::InvalidIdentifier(0, ""),
+            ParsingError::InvalidIdentifier(0, "".to_string()),
         );
     }
 
@@ -47,7 +47,7 @@ Making_Coffee : Ingredients -> Coffee
 makeCoffee : Ingredients -> Coffee
             "#
             .trim_ascii(),
-            ParsingError::InvalidIdentifier(0, ""),
+            ParsingError::InvalidIdentifier(0, "".to_string()),
         );
     }
 
@@ -58,7 +58,7 @@ makeCoffee : Ingredients -> Coffee
 make-coffee : Ingredients -> Coffee
             "#
             .trim_ascii(),
-            ParsingError::InvalidIdentifier(0, ""),
+            ParsingError::InvalidIdentifier(0, "".to_string()),
         );
     }
 
@@ -69,7 +69,7 @@ make-coffee : Ingredients -> Coffee
 make coffee : Ingredients -> Coffee
             "#
             .trim_ascii(),
-            ParsingError::InvalidIdentifier(0, ""),
+            ParsingError::InvalidIdentifier(0, "".to_string()),
         );
     }
 
@@ -135,7 +135,7 @@ making_coffee Ingredients -> Coffee
 making_coffee(BadParam) : Ingredients -> Coffee
             "#
             .trim_ascii(),
-            ParsingError::InvalidIdentifier(14, ""),
+            ParsingError::InvalidIdentifier(14, "".to_string()),
         );
     }
 

--- a/tests/parsing/parser.rs
+++ b/tests/parsing/parser.rs
@@ -4,7 +4,7 @@ mod verify {
     use std::vec;
 
     use technique::language::*;
-    use technique::parsing::parser::{self, Parser};
+    use technique::parsing::parser::Parser;
 
     fn trim(s: &str) -> &str {
         s.strip_prefix('\n')
@@ -1089,7 +1089,7 @@ before_leaving :
 
     #[test]
     fn section_parsing() {
-        let result = technique::parsing::parser::parse_via_taking(
+        let result = technique::parsing::parser::parse_with_recovery(
             Path::new(""),
             trim(
                 r#"
@@ -1177,7 +1177,7 @@ second_section_second_procedure :
 
     #[test]
     fn section_with_procedures_only() {
-        let result = technique::parsing::parser::parse_via_taking(
+        let result = technique::parsing::parser::parse_with_recovery(
             Path::new(""),
             trim(
                 r#"
@@ -1248,7 +1248,7 @@ procedure_four : Concept -> Architecture
 
     #[test]
     fn section_with_procedures() {
-        let result = parser::parse_via_taking(
+        let result = technique::parsing::parser::parse_with_recovery(
             Path::new(""),
             trim(
                 r#"


### PR DESCRIPTION
Until now we have just exited on detecting the first parsing or validation error, but the forthcoming language server will need to know where all the problems are. So the next step in maturing the parser is collecting more than a single error at a time when checking the validity of a document.

The Parser state object is updated to include a Vec<ParsingError> that the parser (and subparsers) can contribute to.

Finally, when reporting errors we deduplicate, with more specific messages overriding enclosing general ones. This is an admittedly rare occurrence, as usually fail-fast short-circuiting will cause a single error to propagate, but in the event nesting results in multiple errors at the same site we trim it down to a single message.